### PR TITLE
added support for NATS JetStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ by [aznamier/keycloak-event-listener-rabbitmq](https://github.com/aznamier/keycl
 Configuration is done via environment variables. I read something about some included XML configuration solution and
 decided not to use it because we don't live in the stone age anymore.
 
-| Environment Variable                 | Data Type | Description                                                               | Default Value           |
-|--------------------------------------|-----------|---------------------------------------------------------------------------|-------------------------|
-| `KEYCLOAK_NATS_STREAMING`            | boolean   | Whether or not to use NATS Streaming (STAN); plain NATS is used otherwise | `false`                 |
-| `KEYCLOAK_NATS_URL`                  | string    | The NATS URL to connect to; may contain authentication details            | `nats://localhost:4222` |
-| `KEYCLOAK_NATS_STREAMING_CLUSTER_ID` | string    | The cluster ID to use when NATS Streaming (STAN) is used                  | `<empty>`               |
-| `KEYCLOAK_NATS_STREAMING_CLIENT_ID`  | string    | The client ID to use when NATS streaming (STAN) is used                   | `<empty>`               |
+| Environment Variable      | Data Type | Description                                                        | Default Value           |
+|---------------------------|-----------|--------------------------------------------------------------------|-------------------------|
+| `KEYCLOAK_NATS_JETSTREAM` | boolean   | Whether or not to use NATS JetStream; plain NATS is used otherwise | `false`                 |
+| `KEYCLOAK_NATS_URL`       | string    | The NATS URL to connect to; may contain authentication details     | `nats://localhost:4222` |
+| `JETSTREAM_ADMIN_SIZE`    | string    | Admin stream size when JetStream is used                           | `1 MB`                  |
+| `JETSTREAM_CLIENT_SIZE`   | string    | Client stream size when JetStream is used                          | `1 MB`                  |
 
 ## Channel Name / Subject
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'li.mesy'
-version '0.2.0'
+version '0.3.0'
 
 repositories {
     mavenCentral()
@@ -18,6 +18,5 @@ dependencies {
     compileOnly "org.keycloak:keycloak-saml-core-public:23.0.0"
     compileOnly "org.jboss.logging:jboss-logging:3.5.3.Final"
 
-    implementation 'io.nats:java-nats-streaming:2.2.3'
-    implementation 'io.nats:jnats:2.17.3'
+    implementation 'io.nats:jnats:2.19.1'
 }

--- a/src/main/java/li/mesy/keycloaktonats/config/Configuration.java
+++ b/src/main/java/li/mesy/keycloaktonats/config/Configuration.java
@@ -13,21 +13,21 @@ import java.util.Optional;
  */
 public class Configuration {
 
-    private final boolean useStreaming;
+    private final boolean useJetStream;
     private final String url;
-    private final String streamingClusterId;
-    private final String streamingClientId;
+    private final int jetStreamAdminSize;
+    private final int jetStreamClientSize;
 
     private Configuration(
-            final boolean useStreaming,
+            final boolean useJetStream,
             final String url,
-            final String streamingClusterId,
-            final String streamingClientId
+            final int jetStreamAdminSize,
+            final int jetStreamClientSize
     ) {
-        this.useStreaming = useStreaming;
+        this.useJetStream = useJetStream;
         this.url = url;
-        this.streamingClusterId = streamingClusterId;
-        this.streamingClientId = streamingClientId;
+        this.jetStreamAdminSize = jetStreamAdminSize;
+        this.jetStreamClientSize = jetStreamClientSize;
     }
 
     /**
@@ -36,33 +36,32 @@ public class Configuration {
      * @return The loaded configuration
      */
     public static Configuration loadFromEnv() {
-        final boolean useStreaming = "true".equalsIgnoreCase(System.getenv("KEYCLOAK_NATS_STREAMING"));
+        final boolean useJetStream = "true".equalsIgnoreCase(System.getenv("KEYCLOAK_NATS_JETSTREAM"));
         final String url = Optional.ofNullable(System.getenv("KEYCLOAK_NATS_URL")).orElse(Options.DEFAULT_URL);
-        final String streamingClusterId = Optional.ofNullable(System.getenv("KEYCLOAK_NATS_STREAMING_CLUSTER_ID")).orElse("");
-        final String streamingClientId = Optional.ofNullable(System.getenv("KEYCLOAK_NATS_STREAMING_CLIENT_ID")).orElse("");
+        final int jetStreamAdminSize = Integer.parseInt(Optional.ofNullable(System.getenv("JETSTREAM_ADMIN_SIZE")).orElse("1"));
+        final int jetStreamClientSize = Integer.parseInt(Optional.ofNullable(System.getenv("JETSTREAM_CLIENT_SIZE")).orElse("1"));
 
         return new Configuration(
-                useStreaming,
+                useJetStream,
                 url,
-                streamingClusterId,
-                streamingClientId
+                jetStreamAdminSize,
+                jetStreamClientSize
         );
     }
 
-    public boolean useStreaming() {
-        return this.useStreaming;
+    public boolean useJetStream() {
+        return this.useJetStream;
     }
 
     public String getUrl() {
         return this.url;
     }
 
-    public String getStreamingClusterId() {
-        return this.streamingClusterId;
+    public int getJetStreamAdminSize() {
+        return jetStreamAdminSize;
     }
 
-    public String getStreamingClientId() {
-        return this.streamingClientId;
+    public int getJetStreamClientSize() {
+        return jetStreamClientSize;
     }
-
 }


### PR DESCRIPTION
As NATS Streaming is deprecated since June of 2023, I replaced it's support with NATS JetStream.

https://github.com/nats-io/nats-streaming-server?tab=readme-ov-file#warning--deprecation-notice-warning