### PR TITLE
Add flag to skip stream creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,7 @@ gradle-app.setting
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
 
+# vs code
+.vscode/
+
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,gradle,java

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ decided not to use it because we don't live in the stone age anymore.
 | Environment Variable      | Data Type | Description                                                        | Default Value           |
 |---------------------------|-----------|--------------------------------------------------------------------|-------------------------|
 | `KEYCLOAK_NATS_JETSTREAM` | boolean   | Whether or not to use NATS JetStream; plain NATS is used otherwise | `false`                 |
+| `KEYCLOAK_NATS_JETSTREAM_MKEYCLOAK_NATS_JETSTREAM_MANAGE_STREAMS` | boolean   | Whether or not to let the plugin create and manage streams | `true`                 |
 | `KEYCLOAK_NATS_URL`       | string    | The NATS URL to connect to; may contain authentication details     | `nats://localhost:4222` |
 | `JETSTREAM_ADMIN_SIZE`    | string    | Admin stream size when JetStream is used                           | `1 MB`                  |
 | `JETSTREAM_CLIENT_SIZE`   | string    | Client stream size when JetStream is used                          | `1 MB`                  |

--- a/src/main/java/ebbot/keycloaktonats/config/Configuration.java
+++ b/src/main/java/ebbot/keycloaktonats/config/Configuration.java
@@ -17,17 +17,20 @@ public class Configuration {
     private final String url;
     private final int jetStreamAdminSize;
     private final int jetStreamClientSize;
+    private final boolean jetStreamManageStreams; 
 
     private Configuration(
             final boolean useJetStream,
             final String url,
             final int jetStreamAdminSize,
-            final int jetStreamClientSize
+            final int jetStreamClientSize,
+            final boolean jetStreamManageStreams
     ) {
         this.useJetStream = useJetStream;
         this.url = url;
         this.jetStreamAdminSize = jetStreamAdminSize;
         this.jetStreamClientSize = jetStreamClientSize;
+        this.jetStreamManageStreams = jetStreamManageStreams;
     }
 
     /**
@@ -40,17 +43,23 @@ public class Configuration {
         final String url = Optional.ofNullable(System.getenv("KEYCLOAK_NATS_URL")).orElse(Options.DEFAULT_URL);
         final int jetStreamAdminSize = Integer.parseInt(Optional.ofNullable(System.getenv("JETSTREAM_ADMIN_SIZE")).orElse("1"));
         final int jetStreamClientSize = Integer.parseInt(Optional.ofNullable(System.getenv("JETSTREAM_CLIENT_SIZE")).orElse("1"));
+        final boolean jetStreamManageStreams = !"false".equalsIgnoreCase(System.getenv("KEYCLOAK_NATS_JETSTREAM_MANAGE_STREAMS"));
 
         return new Configuration(
                 useJetStream,
                 url,
                 jetStreamAdminSize,
-                jetStreamClientSize
+                jetStreamClientSize,
+                jetStreamManageStreams
         );
     }
 
     public boolean useJetStream() {
         return this.useJetStream;
+    }
+
+    public boolean jetStreamManageStreams() {
+        return this.jetStreamManageStreams;
     }
 
     public String getUrl() {

--- a/src/main/java/ebbot/keycloaktonats/provider/NATSEventListenerProviderFactory.java
+++ b/src/main/java/ebbot/keycloaktonats/provider/NATSEventListenerProviderFactory.java
@@ -51,8 +51,10 @@ public class NATSEventListenerProviderFactory implements EventListenerProviderFa
 
             if (config.useJetStream()) {
                 // Use JetStream connection
-                buildAdminEventStream(natsConnection, config);
-                buildClientEventStream(natsConnection, config);
+                if (config.jetStreamManageStreams()) {
+                    buildAdminEventStream(natsConnection, config);
+                    buildClientEventStream(natsConnection, config);
+                }
 
                 this.listener = new NATSEventListenerProvider(natsConnection.jetStream(), natsConnection);
             } else {


### PR DESCRIPTION
### Summary

The plugin now accepts the flag `KEYCLOAK_NATS_JETSTREAM_MANAGE_STREAMS` ("true" by default) which keeps the standard usage.
When set to "false", streams won't be created but the application will still verify that some matching stream accepted the message.
